### PR TITLE
Use `get_app_model` instead of `get_app` for napari>=0.5.4

### DIFF
--- a/midi_app_controller/actions/_tests/test_napari_actions.py
+++ b/midi_app_controller/actions/_tests/test_napari_actions.py
@@ -137,6 +137,8 @@ def test_zoom_and_dimensions():
     increase_dimensions_left(viewer)
     increase_dimensions_right(viewer)
 
+    viewer.close()
+
 
 def test_contour():
     layer = Labels(np.ones((4, 4), dtype=np.int32))

--- a/midi_app_controller/actions/_tests/test_napari_actions.py
+++ b/midi_app_controller/actions/_tests/test_napari_actions.py
@@ -4,7 +4,6 @@ from napari.components import LayerList
 from napari.layers import Image
 from napari.layers.labels import Labels
 from napari.layers.labels._labels_constants import Mode
-from napari.viewer import Viewer
 
 from ..napari_actions import (
     activate_labels_mode,
@@ -121,8 +120,8 @@ def test_selected_label():
     assert other_layer.selected_label == 5
 
 
-def test_zoom_and_dimensions():
-    viewer = Viewer()
+def test_zoom_and_dimensions(make_napari_viewer):
+    viewer = make_napari_viewer()
     zoom = viewer.camera.zoom
 
     zoom_out(viewer)
@@ -136,8 +135,6 @@ def test_zoom_and_dimensions():
 
     increase_dimensions_left(viewer)
     increase_dimensions_right(viewer)
-
-    viewer.close()
 
 
 def test_contour():

--- a/midi_app_controller/state/state_manager.py
+++ b/midi_app_controller/state/state_manager.py
@@ -7,7 +7,7 @@ from app_model.registries import MenusRegistry
 from app_model.types import CommandRule, MenuItem
 
 # TODO: This will be made public in some future napari version
-from napari._app_model import get_app
+from napari._app_model import get_app_model
 
 from midi_app_controller.actions.actions_handler import ActionsHandler
 from midi_app_controller.actions.bound_controller import BoundController
@@ -364,7 +364,7 @@ def get_state_manager() -> StateManager:
     """Returns the `StateManager` singleton."""
     global _STATE_MANAGER
     if _STATE_MANAGER is None:
-        register_custom_napari_actions(get_app())
-        _STATE_MANAGER = StateManager(get_app())
+        register_custom_napari_actions(get_app_model())
+        _STATE_MANAGER = StateManager(get_app_model())
         _STATE_MANAGER.load_state()
     return _STATE_MANAGER

--- a/midi_app_controller/state/state_manager.py
+++ b/midi_app_controller/state/state_manager.py
@@ -7,7 +7,10 @@ from app_model.registries import MenusRegistry
 from app_model.types import CommandRule, MenuItem
 
 # TODO: This will be made public in some future napari version
-from napari._app_model import get_app_model
+try:
+    from napari._app_model import get_app_model
+except ImportError:
+    from napari._app_model import get_app as get_app_model
 
 from midi_app_controller.actions.actions_handler import ActionsHandler
 from midi_app_controller.actions.bound_controller import BoundController

--- a/midi_app_controller/state/state_manager.py
+++ b/midi_app_controller/state/state_manager.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version
 from pathlib import Path
 from typing import NamedTuple, Optional
 
@@ -5,11 +6,12 @@ import rtmidi
 from app_model import Application
 from app_model.registries import MenusRegistry
 from app_model.types import CommandRule, MenuItem
+from packaging.version import parse as parse_version
 
 # TODO: This will be made public in some future napari version
-try:
+if parse_version(version("napari")) >= parse_version("0.5.4"):
     from napari._app_model import get_app_model
-except ImportError:
+else:
     from napari._app_model import get_app as get_app_model
 
 from midi_app_controller.actions.actions_handler import ActionsHandler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "napari[all]>=0.5.4",
+    "napari[all]>=0.4.19",
     "python-rtmidi>=1.5.8",
     "pyyaml>=6.0.1",
     "pydantic>=2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "napari[all]>=0.4.19",
+    "napari[all]>=0.5.4",
     "python-rtmidi>=1.5.8",
     "pyyaml>=6.0.1",
     "pydantic>=2.7.1",


### PR DESCRIPTION
Hi there, as part of https://github.com/napari/napari/issues/6054 usage of `get_app` is being deprecated ( over PR https://github.com/napari/napari/pull/7269 ). This PR changes things to use `get_app_model` instead of `get_app`. It also bumps the `napari` version constraint to `>=0.5.4`