### PR TITLE
Check knob and button IDs separately for conflicts

### DIFF
--- a/midi_app_controller/models/_tests/test_binds.py
+++ b/midi_app_controller/models/_tests/test_binds.py
@@ -59,6 +59,19 @@ def test_valid_binds(binds_data):
                 },
             ],
         ),
+    ],
+)
+def test_binds_duplicate_id(binds_data, button_binds, knob_binds):
+    binds_data["button_binds"] = button_binds
+    binds_data["knob_binds"] = knob_binds
+
+    with pytest.raises(ValidationError):
+        Binds(**binds_data)
+
+
+@pytest.mark.parametrize(
+    "button_binds, knob_binds",
+    [
         (
             [{"button_id": 1, "action_id": "Action1"}],
             [
@@ -71,12 +84,10 @@ def test_valid_binds(binds_data):
         ),
     ],
 )
-def test_binds_duplicate_id(binds_data, button_binds, knob_binds):
+def test_allow_knob_button_collision(binds_data, button_binds, knob_binds):
     binds_data["button_binds"] = button_binds
     binds_data["knob_binds"] = knob_binds
-
-    with pytest.raises(ValidationError):
-        Binds(**binds_data)
+    Binds(**binds_data)
 
 
 @pytest.mark.parametrize("id", [-1, 128])

--- a/midi_app_controller/models/binds.py
+++ b/midi_app_controller/models/binds.py
@@ -69,8 +69,14 @@ class Binds(YamlBaseModel):
         button_ids = [bind.button_id for bind in values.button_binds]
         knob_ids = [bind.knob_id for bind in values.knob_binds]
 
-        duplicate = find_duplicate(button_ids + knob_ids)
-        if duplicate is not None:
-            raise ValueError(f"id={duplicate} was bound to multiple actions")
+        duplicate_buttons = find_duplicate(button_ids)
+        if duplicate_buttons is not None:
+            raise ValueError(
+                f"button id={duplicate_buttons} was bound to multiple actions"
+            )
+
+        duplicate_knobs = find_duplicate(knob_ids)
+        if duplicate_knobs is not None:
+            raise ValueError(f"knob id={duplicate_knobs} was bound to multiple actions")
 
         return values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ midi-app-controller = "midi_app_controller:napari.yaml"
 testing = [
     "pytest>=8.2.0",
     "pytest-cov>=5.0.0",
-    "pytest-qt>=4.0.2"
+    "pytest-qt>=4.0.2",
+    "flexparser!=0.4.0"  # see https://napari.zulipchat.com/#narrow/channel/212875-general/topic/broken.20pint.2Fflexparser/near/481110284
 ]
 dev = [
     "midi-app-controller[testing]",


### PR DESCRIPTION
Closes #104

As noted in [#104 (comment)](https://github.com/napari/midi-app-controller/issues/104#issuecomment-2461860941), the validator attempts to ensure that the knob and button IDs are unique jointly, but the IDs of the knobs and those of the buttons actually overlap in the controller (see the controller definition [here](https://github.com/napari/midi-app-controller/blob/0e5029961aa2bc30fec743cb4dba30b427dd407c/midi_app_controller/config_files/controllers/x_touch_mini.yaml)).

This PR therefore removes the Pydantic requirement for the button IDs to not clash with the knob IDs.

