### PR TITLE
Use setuptools_scm correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "midi-app-controller"
-version = "0.0.12"
 description = "Control napari with a MIDI controller."
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
@@ -45,6 +45,9 @@ dev = [
 
 [tool.setuptools.packages.find]
 namespaces = true
+
+[tool.setuptools_scm]
+write_to = "midi_app_controller/_version.py"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Closes #106

I verified locally that it's working:

```
Successfully installed PyQt5-5.15.11 PyQt5-Qt5-5.15.15 PyQt5-sip-12.15.0 midi-app-controller-0.0.13.dev2+gd851237.d20241108
```

(ignore PyQt, this branch didn't include #110 😅)
