### PR TITLE
[Docs] fix pip install commands when using zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python3 -m pip install -e .
 
 ### Testing
 ```sh
-python3 -m pip install -e .[testing]
+python3 -m pip install -e ".[testing]"
 python3 -m pytest --cov .
 ```
 
@@ -90,6 +90,6 @@ mkdocs serve -a localhost:8080
 
 ### Using pre-commit
 ```sh
-python3 -m pip install -e .[dev]
+python3 -m pip install -e ".[dev]"
 pre-commit install
 ```


### PR DESCRIPTION
Fixes e.g.: 

```
zsh: no matches found: .[testing]
``` 